### PR TITLE
Add support for a review environment

### DIFF
--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -1,0 +1,102 @@
+###########
+# BUILDER #
+###########
+
+FROM milmove/circleci-docker:milmove-app-eaef02734833321cab72652613f07651fc7c99f0 as server_builder
+
+ENV CIRCLECI=docker
+ENV GOPATH=/go
+ENV PATH=/go/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+USER root
+WORKDIR /build
+RUN mkdir /go
+
+# go build needs
+## populate go module cache
+COPY go.mod go.sum /build/
+RUN go mod download
+
+# set args after module cache so mod cache isn't invalidated when
+# changing branches
+ARG GIT_BRANCH
+ARG GIT_COMMIT
+
+# copy everything else
+COPY Makefile /build/
+COPY cmd /build/cmd
+COPY swagger /build/swagger
+COPY pkg /build/pkg
+COPY scripts /build/scripts
+
+# fake src dir to silence make
+RUN mkdir /build/src
+
+RUN set -x \
+  && make bin/rds-ca-2019-root.pem \
+  && rm -f pkg/assets/assets.go && make pkg/assets/assets.go \
+  && make server_generate \
+  && rm -f bin/milmove && make bin/milmove
+
+FROM milmove/circleci-docker:milmove-app-eaef02734833321cab72652613f07651fc7c99f0 as client_builder
+
+ENV CIRCLECI=docker
+ENV REACT_APP_NODE_ENV=development
+USER root
+WORKDIR /build
+
+COPY Makefile /build/
+COPY scripts /build/scripts
+
+# js build needs
+COPY .eslintignore .eslintrc .prettierignore .prettierrc .yarnrc \
+  config-overrides.js jsconfig.json package.json terser-rescript.js \
+  yarn.lock wallaby.js /build/
+COPY public /build/public
+COPY src /build/src
+
+RUN set -x \
+  && yarn install \
+  && yarn build
+
+FROM alpine:3.12.3 as migrate
+
+COPY --from=server_builder /build/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
+COPY --from=server_builder /build/bin/milmove /bin/milmove
+
+COPY migrations/app/schema /migrate/schema
+COPY migrations/app/secure /migrate/secure
+COPY migrations/app/migrations_manifest.txt /migrate/migrations_manifest.txt
+
+# Install tools needed in container
+RUN apk update && apk add ca-certificates --no-cache
+
+WORKDIR /
+
+USER nobody
+
+ENTRYPOINT ["/bin/milmove", "migrate", "-p", "file:///migrate/migrations", "-m", "/migrate/migrations_manifest.txt"]
+
+#########
+# FINAL #
+#########
+
+FROM gcr.io/distroless/base:latest
+
+COPY --from=server_builder /build/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
+COPY --from=server_builder /build/bin/milmove /bin/milmove
+COPY --from=server_builder /build/swagger /swagger
+
+COPY --from=client_builder /build/build /build
+
+COPY config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b /config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
+COPY config/tls/dod-sw-ca-54.pem /config/tls/dod-sw-ca-54.pem
+
+# While it's ok to have these certs copied locally, they should never be copied into Dockerfile.
+COPY config/tls/devlocal-ca.key /config/tls/devlocal-ca.key
+COPY config/tls/devlocal-ca.pem /config/tls/devlocal-ca.pem
+
+  ENTRYPOINT ["/bin/milmove"]
+
+CMD ["serve", "--logging-level=debug"]
+
+EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ ifeq ($(USE_AWS),true)
 endif
 
 # Convenience for LDFLAGS
-WEBSERVER_LDFLAGS=-X main.gitBranch=$(shell git branch | grep \* | cut -d ' ' -f2) -X main.gitCommit=$(shell git rev-list -1 HEAD)
+GIT_BRANCH ?= $(shell git branch | grep \* | cut -d ' ' -f2)
+GIT_COMMIT ?= $(shell git rev-list -1 HEAD)
+export GIT_BRANCH GIT_COMMIT
+WEBSERVER_LDFLAGS=-X main.gitBranch=$(GIT_BRANCH) -X main.gitCommit=$(GIT_COMMIT)
 GC_FLAGS=-trimpath=$(GOPATH)
 DB_PORT_DEV=5432
 DB_PORT_TEST=5433
@@ -1068,6 +1071,17 @@ schemaspy: db_test_reset db_test_migrate ## Generates database documentation usi
 		-t pgsql11 -host host.docker.internal -port $(DB_PORT_TEST) -db $(DB_NAME_TEST) -u postgres -p $(PGPASSWORD) \
 		-norows -nopages
 	@echo "Schemaspy output can be found in $(SCHEMASPY_OUTPUT)"
+
+.PHONY: reviewapp_docker
+reviewapp_docker:
+	docker-compose -f docker-compose.reviewapp.yml up
+
+.PHONY: reviewapp_docker_build
+reviewapp_docker_build:
+# remove bin to maybe speed up docker builds by removing it from
+# docker context
+	rm -rf ./bin
+	docker-compose -f docker-compose.reviewapp.yml build
 
 #
 # ----- END RANDOM TARGETS -----

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -964,7 +964,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		localAuthMux.Handle(pat.Post("/new"), authentication.NewCreateAndLoginUserHandler(authContext, dbConnection, appnames))
 		localAuthMux.Handle(pat.Post("/create"), authentication.NewCreateUserHandler(authContext, dbConnection, appnames))
 
-		if stringSliceContains([]string{cli.EnvironmentTest, cli.EnvironmentDevelopment}, v.GetString(cli.EnvironmentFlag)) {
+		if stringSliceContains([]string{cli.EnvironmentTest, cli.EnvironmentDevelopment, cli.EnvironmentReview}, v.GetString(cli.EnvironmentFlag)) {
 			logger.Info("Adding devlocal CA to root CAs")
 			devlocalCAPath := v.GetString(cli.DevlocalCAFlag)
 			devlocalCa, readFileErr := ioutil.ReadFile(filepath.Clean(devlocalCAPath))

--- a/docker-compose.ecs.yml
+++ b/docker-compose.ecs.yml
@@ -1,0 +1,119 @@
+version: '3'
+
+services:
+  database:
+    image: postgres:12.4
+    # ports:
+    #   - '5432:5432'
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=mysecretpassword
+      - POSTGRES_DB=dev_db
+    logging:
+      driver: awslogs
+      options:
+        awslogs-group: mymove
+        awslogs-region: us-east-1
+        awslogs-stream-prefix: mymove
+
+  redis:
+    image: redis:5.0.6
+    logging:
+      driver: awslogs
+      options:
+        awslogs-group: mymove
+        awslogs-region: us-east-1
+        awslogs-stream-prefix: mymove
+
+  milmove_migrate:
+    image: 867136165464.dkr.ecr.us-east-1.amazonaws.com/milmove:migrate_ahobson
+    environment:
+      - DB_ENV=development
+      - DB_HOST=127.0.0.1
+      - DB_NAME=dev_db
+      - DB_PASSWORD=mysecretpassword
+      - DB_PORT=5432
+      - DB_SSL_MODE=disable
+      - DB_USER=postgres
+      - ENVIRONMENT=review
+      - MIGRATION_PATH=file:///migrate/schema;file:///migrate/secure
+      - MIGRATION_MANIFEST=/migrate/migrations_manifest.txt
+    entrypoint:
+      - '/bin/milmove'
+      - 'migrate'
+    logging:
+      driver: awslogs
+      options:
+        awslogs-group: mymove
+        awslogs-region: us-east-1
+        awslogs-stream-prefix: mymove
+
+  milmove:
+    image: 867136165464.dkr.ecr.us-east-1.amazonaws.com/milmove:milmove_ahobson
+    ports:
+      - '4000:4000'
+      - '9443:9443'
+    environment:
+      - CLIENT_AUTH_SECRET_KEY
+      - CSRF_AUTH_KEY
+      - DB_DEBUG=1
+      - DB_ENV=development
+      - DB_HOST=127.0.0.1
+      - DB_NAME=dev_db
+      - DB_PASSWORD=mysecretpassword
+      - DB_PORT=5432
+      - DB_REGION=us-west-2
+      - DB_RETRY_INTERVAL=5s
+      - DB_SSL_MODE=disable
+      - DB_USER=postgres
+      - DEVLOCAL_AUTH=1
+      - DEVLOCAL_CA=/config/tls/devlocal-ca.pem
+      - DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
+      - DPS_AUTH_COOKIE_SECRET_KEY
+      - DPS_COOKIE_EXPIRES_IN_MINUTES
+      - EIA_KEY=db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
+      - ENVIRONMENT=review
+      - FEATURE_FLAG_ACCESS_CODE=false
+      - HERE_MAPS_APP_CODE
+      - HERE_MAPS_APP_ID
+      - HERE_MAPS_GEOCODE_ENDPOINT
+      - HERE_MAPS_ROUTING_ENDPOINT
+      - HTTP_ADMIN_SERVER_NAME=admin-${REVIEW_BASE_DOMAIN}
+      - HTTP_MY_SERVER_NAME=my-${REVIEW_BASE_DOMAIN}
+      - HTTP_OFFICE_SERVER_NAME=office-${REVIEW_BASE_DOMAIN}
+      - HTTP_ORDERS_SERVER_NAME=orders-${REVIEW_BASE_DOMAIN}
+      - HTTP_PRIME_SERVER_NAME=prime-${REVIEW_BASE_DOMAIN}
+      - AWS_CF_DOMAIN=assets.devlocal.move.mil
+      - IWS_RBS_ENABLED=1
+      - IWS_RBS_HOST
+      - LOCAL_STORAGE_ROOT=/tmp
+      - LOCAL_STORAGE_WEB_ROOT=storage
+      - LOGIN_GOV_ADMIN_CLIENT_ID
+      - LOGIN_GOV_CALLBACK_PORT=443
+      - LOGIN_GOV_CALLBACK_PROTOCOL
+      - LOGIN_GOV_HOSTNAME
+      - LOGIN_GOV_MY_CLIENT_ID
+      - LOGIN_GOV_OFFICE_CLIENT_ID
+      - LOGIN_GOV_SECRET_KEY
+      - MOVE_MIL_DOD_CA_CERT
+      - MOVE_MIL_DOD_TLS_CERT
+      - MOVE_MIL_DOD_TLS_KEY
+      - MUTUAL_TLS_ENABLED=0
+      - NO_TLS_ENABLED=1
+      - NO_TLS_PORT=4000
+      - PGPASSWORD=mysecretpassword
+      - REDIS_HOST=127.0.0.1
+      - REVIEW_BASE_DOMAIN=branchone.reasonabowl.com
+      - SERVE_ADMIN=true
+      - SERVE_API_GHC=false
+      - SERVE_API_INTERNAL=true
+      - SERVE_API_PRIME=false
+      - STORAGE_BACKEND=local
+      - TLS_ENABLED=1
+      - TZ=UTC
+    logging:
+      driver: awslogs
+      options:
+        awslogs-group: mymove
+        awslogs-region: us-east-1
+        awslogs-stream-prefix: mymove

--- a/docker-compose.reviewapp.yml
+++ b/docker-compose.reviewapp.yml
@@ -1,0 +1,118 @@
+version: '3.4'
+
+services:
+  database:
+    image: postgres:12.4
+    restart: always
+    ports:
+      - '6432:5432'
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=mysecretpassword
+      - POSTGRES_DB=dev_db
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  redis:
+    image: redis:5.0.6
+
+  milmove_migrate:
+    depends_on:
+      - database
+    build:
+      context: .
+      dockerfile: Dockerfile.reviewapp
+      target: migrate
+      args:
+        GIT_BRANCH: ${GIT_BRANCH:-unknown}
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
+    links:
+      - database
+    environment:
+      - DB_ENV=development
+      - DB_HOST=database
+      - DB_NAME=dev_db
+      - DB_PASSWORD=mysecretpassword
+      - DB_PORT=5432
+      - DB_SSL_MODE=disable
+      - DB_USER=postgres
+      - ENVIRONMENT=review
+      - MIGRATION_PATH=file:///migrate/schema;file:///migrate/secure
+      - MIGRATION_MANIFEST=/migrate/migrations_manifest.txt
+    entrypoint:
+      - '/bin/milmove'
+      - 'migrate'
+
+  milmove:
+    depends_on:
+      - database
+      - milmove_migrate
+      - redis
+    build:
+      context: .
+      dockerfile: Dockerfile.reviewapp
+      args:
+        GIT_BRANCH: ${GIT_BRANCH:-unknown}
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
+    links:
+      - database
+    ports:
+      - '4000:4000'
+      - '9443:9443'
+    environment:
+      - CLIENT_AUTH_SECRET_KEY
+      - CSRF_AUTH_KEY
+      - DB_DEBUG=1
+      - DB_ENV=development
+      - DB_HOST=database
+      - DB_NAME=dev_db
+      - DB_PASSWORD=mysecretpassword
+      - DB_PORT=5432
+      - DB_REGION=us-west-2
+      - DB_RETRY_INTERVAL=5s
+      - DB_SSL_MODE=disable
+      - DB_USER=postgres
+      - DEVLOCAL_AUTH=1
+      - DEVLOCAL_CA=/config/tls/devlocal-ca.pem
+      - DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
+      - DPS_AUTH_COOKIE_SECRET_KEY
+      - DPS_COOKIE_EXPIRES_IN_MINUTES
+      - EIA_KEY=db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
+      - ENVIRONMENT=review
+      - FEATURE_FLAG_ACCESS_CODE=false
+      - HERE_MAPS_APP_CODE
+      - HERE_MAPS_APP_ID
+      - HERE_MAPS_GEOCODE_ENDPOINT
+      - HERE_MAPS_ROUTING_ENDPOINT
+      - HTTP_ADMIN_SERVER_NAME=adminlocal
+      - HTTP_MY_SERVER_NAME=milmovelocal
+      - HTTP_OFFICE_SERVER_NAME=officelocal
+      - HTTP_ORDERS_SERVER_NAME=orderslocal
+      - HTTP_PRIME_SERVER_NAME=primelocal
+      - AWS_CF_DOMAIN=assets.devlocal.move.mil
+      - IWS_RBS_ENABLED=1
+      - IWS_RBS_HOST
+      - LOCAL_STORAGE_ROOT=/tmp
+      - LOCAL_STORAGE_WEB_ROOT=storage
+      - LOGIN_GOV_ADMIN_CLIENT_ID
+      - LOGIN_GOV_CALLBACK_PORT=4000
+      - LOGIN_GOV_CALLBACK_PROTOCOL
+      - LOGIN_GOV_HOSTNAME
+      - LOGIN_GOV_MY_CLIENT_ID
+      - LOGIN_GOV_OFFICE_CLIENT_ID
+      - LOGIN_GOV_SECRET_KEY
+      - MOVE_MIL_DOD_CA_CERT
+      - MOVE_MIL_DOD_TLS_CERT
+      - MOVE_MIL_DOD_TLS_KEY
+      - MUTUAL_TLS_ENABLED=0
+      - NO_TLS_ENABLED=1
+      - NO_TLS_PORT=4000
+      - PGPASSWORD=mysecretpassword
+      - REDIS_HOST=redis
+      - SERVE_ADMIN=true
+      - SERVE_API_GHC=false
+      - SERVE_API_INTERNAL=true
+      - SERVE_API_PRIME=false
+      - STORAGE_BACKEND=local
+      - TLS_ENABLED=1
+      - TZ=UTC

--- a/ecs-params.yml
+++ b/ecs-params.yml
@@ -1,0 +1,19 @@
+version: 1
+task_definition:
+  task_execution_role: ecsTaskExecutionRole
+  ecs_network_mode: awsvpc
+  task_size:
+    mem_limit: 1024
+    cpu_limit: 512
+  services:
+    milmove_migrate:
+      essential: false
+run_params:
+  network_configuration:
+    awsvpc_configuration:
+      subnets:
+        - "subnet-08e32debfdc07b581"
+        - "subnet-0971763f524ecc4b2"
+      security_groups:
+        - "sg-0913dc638b6cff859"
+      assign_public_ip: ENABLED

--- a/pkg/cli/devlocal.go
+++ b/pkg/cli/devlocal.go
@@ -26,14 +26,18 @@ func CheckDevlocal(v *viper.Viper) error {
 			EnvironmentDevelopment,
 			EnvironmentTest,
 			EnvironmentExperimental,
+			EnvironmentReview,
 		}
 		if environment := v.GetString(EnvironmentFlag); !stringSliceContains(allowedEnvironments, environment) {
 			return errors.Errorf("Devlocal Auth cannot run in the '%s' environment, only in %v", environment, allowedEnvironments)
 		}
 
+		reviewBaseDomain := v.GetString(ReviewBaseDomainFlag)
+
 		// Check against My Server Names
 		allowedMyServerNames := []string{
 			HTTPMyServerNameLocal,
+			fmt.Sprintf("my-%s", reviewBaseDomain),
 			fmt.Sprintf("my.%s.move.mil", EnvironmentExperimental),
 		}
 		if serverName := v.GetString(HTTPMyServerNameFlag); !stringSliceContains(allowedMyServerNames, serverName) {
@@ -43,6 +47,7 @@ func CheckDevlocal(v *viper.Viper) error {
 		// Check against Office Server Names
 		allowedOfficeServerNames := []string{
 			HTTPOfficeServerNameLocal,
+			fmt.Sprintf("office-%s", reviewBaseDomain),
 			fmt.Sprintf("office.%s.move.mil", EnvironmentExperimental),
 		}
 		if serverName := v.GetString(HTTPOfficeServerNameFlag); !stringSliceContains(allowedOfficeServerNames, serverName) {
@@ -52,6 +57,7 @@ func CheckDevlocal(v *viper.Viper) error {
 		// Check against Admin Server Names
 		allowedAdminServerNames := []string{
 			HTTPAdminServerNameLocal,
+			fmt.Sprintf("admin-%s", reviewBaseDomain),
 			fmt.Sprintf("admin.%s.move.mil", EnvironmentExperimental),
 		}
 		if serverName := v.GetString(HTTPAdminServerNameFlag); !stringSliceContains(allowedAdminServerNames, serverName) {

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -11,6 +11,11 @@ const (
 	// EnvironmentFlag is the Environment Flag
 	EnvironmentFlag string = "environment"
 
+	// ReviewBaseDomainFlag is the base domain name for review apps
+	ReviewBaseDomainFlag = "review-base-domain"
+	// ReviewBaseDomainDefault is the default base domain for review apps
+	ReviewBaseDomainDefault = "review.localhost"
+
 	// EnvironmentProd is the Production Environment name
 	EnvironmentProd string = "prod"
 	// EnvironmentStaging is the Staging Environment name
@@ -27,6 +32,8 @@ const (
 	EnvironmentStg string = "stg"
 	// EnvironmentPrd is the GovCloud prd Environment name
 	EnvironmentPrd string = "prd"
+	// EnvironmentReview is a reviewapp
+	EnvironmentReview string = "review"
 )
 
 var environments = []string{
@@ -38,11 +45,21 @@ var environments = []string{
 	EnvironmentExp,
 	EnvironmentStg,
 	EnvironmentPrd,
+	EnvironmentReview,
+}
+
+type errInvalidEnvironment struct {
+	Environment string
+}
+
+func (e *errInvalidEnvironment) Error() string {
+	return fmt.Sprintf("invalid environment %q, expecting one of %q", e.Environment, environments)
 }
 
 // InitEnvironmentFlags initializes the Environment command line flags
 func InitEnvironmentFlags(flag *pflag.FlagSet) {
 	flag.StringP(EnvironmentFlag, "e", EnvironmentDevelopment, fmt.Sprintf("The environment name, one of %v", environments))
+	flag.String(ReviewBaseDomainFlag, ReviewBaseDomainDefault, fmt.Sprintf("The base domain name for review apps, defaults to %s", ReviewBaseDomainDefault))
 }
 
 // CheckEnvironment validates the Environment command line flags


### PR DESCRIPTION
* Allows configuring base domain as environment variable to support
  ephemeral environments
* Add new docker compose config for running reviewapp locally and in
  ecs
* Build react as dev environment for e.g. devlocal login
* Still some hardcoded config in ecs-params and docker-compose.ecs.yml
  for deploying via ecs-cli

## Description

1. `ecs-cli up` creates VPC and subnets by default, but we want to
   manage those separately, so manually create VPC and subnets

1. create ecs cluster per branch

        ecs-cli up --launch-type FARGATE --region $AWS_REGION \
          -c branchone --vpc VPC_ID  \
          --subnets SUBNET_1_ID,SUBNET_2_ID

1. Created ALB with wildcard cert, set up wildcard dns pointing to the
   ALB using [aws docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-application-load-balancer.html)
    1. HTTPS protocol for listener
    1. new SG with HTTPS
    1. target group using IP, port 4000, path health
    1. no targets

1. deploy using ecs-cli

        ecs-cli compose --file docker-compose.ecs.yml --project-name milmove service up \
        --create-log-groups --cluster branchone --launch-type FARGATE --target-groups \
        'targetGroupArn=REAL_TARGET_GROUP_ARN,containerName=milmove,containerPort=4000'
